### PR TITLE
Added sidebar and keyboard components to manage further operations and display set data, managed to diagram every intersection available with the elements of the sets provided

### DIFF
--- a/src/Context/index.jsx
+++ b/src/Context/index.jsx
@@ -33,9 +33,8 @@ export const SetProvider = ({children }) =>{
     //starts like this, then it will change to the intersections evaluated at the end of the function
     let currentIntersectionsEvaluated = [...allSetsAvailable]
 
-    const possibleIntersections = (intersectionsToEvaluate, allSets) => {
-        //intersections to evalate will be the previous evaluated intersections
-
+    const possibleIntersections = (intersectionsToEvaluate, allSets)=>{
+        let newIntersections = []
         //this is just so it can be splited below if they are arrays, transforming every element into a string
         let intersectSet = [...intersectionsToEvaluate]
     
@@ -43,29 +42,20 @@ export const SetProvider = ({children }) =>{
         if(typeof intersectionsToEvaluate[0] === 'object'){
             intersectSet = intersectionsToEvaluate.map(el => el.join(','))
         }
-        //stores the new intersections with duplicates, before purging
-        let newIntersections = []
-        //this will loop through every current intersection
-        for(let i = 0; i< intersectSet.length; i++){
-            //this other loop is to evaluate every intersection with every element available
-            for(let j=0; j<allSets.length; j++){
-                let currSetToEval = intersectSet[i]
-                let currElToEval = allSets[j]
-                //this will be used to check if the element has been already evaluated to prevent intersections like 'A,A'
-                let elementRegexp = new RegExp(`${currElToEval}`)
-                //if it finds a match it is the same set, those intersections are redundadnt and unnecesary
-                if(!currSetToEval.match(elementRegexp)){       
-                    //sorts the intersection elements before storing them, so they can be properly purged
-                    //also adds the new element evaluated (wich is new and unique to the previous stored)
-                    let sortedIntersectionPlusEl = [...currSetToEval.split(','), currElToEval].toSorted()
-                
-                    newIntersections.push([...sortedIntersectionPlusEl])
+        let arrsToEval = [[...intersectSet], [...allSets]]
+        //first it flattens the first array then maps it extracting the first and second arrays elements, then compares them
+        //if it finds a match that is an 'A','A' intersection wich is redundant
+        //then pushes the combination to an array wich be purged
+        arrsToEval.reduce((farr, secarr) => {
+            return farr.flatMap(el => secarr.map(secel => {
+                let elementRegexp = new RegExp(`${secel}`)
+                if(!el.match(elementRegexp)){
+                    newIntersections.push([...el.split(','), secel].flat().toSorted())
                 }
-            }
-        }
+            }))
+        })
 
         let intersectionsTexts = newIntersections.map(el => el.join(','))
-    
         //purge duplicates
         let uniqueIntersectionsTexts = [... new Set(intersectionsTexts)]
         //revert to array with unique elements
@@ -75,26 +65,17 @@ export const SetProvider = ({children }) =>{
         currentIntersectionsEvaluated = [...purgedIntersections]
 
         return purgedIntersections  
-
     }
     //this for statement runs the function for every set so it can get all intersections possible
     
-        for(let r = 0; r < setelements.length; r++){
-            let freshIntersections = possibleIntersections(currentIntersectionsEvaluated, allSetsAvailable)
-            if(freshIntersections.length > 0){
-                allIntersectionsPossible = [...allIntersectionsPossible, ...freshIntersections]
-            }
+    for(let r = 0; r < setelements.length-1; r++){
+        let freshIntersections = possibleIntersections(currentIntersectionsEvaluated, allSetsAvailable)
+        if(freshIntersections.length > 0){
+            allIntersectionsPossible = [...allIntersectionsPossible, ...freshIntersections]
+            console.log(allIntersectionsPossible)
         }
-        const intersectionsToAdd = allIntersectionsPossible.map(el => {
-            return {sets: [...el], elements:[]}
-        })
-        const addIntersections = []
-        if(intersectionsToAdd.length > 0){
-            addIntersections.push(intersectionsToAdd)
-        }
-        console.log(allIntersectionsPossible)
-        console.log(intersectionsToAdd)   
-    
+    }
+
     const addSet = (e) => {
         e.preventDefault()
         const setname = e.target.elements.setname.value

--- a/src/Context/index.jsx
+++ b/src/Context/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useReducer } from "react";
 import { createContext, useState } from "react";
 export const SetContext = createContext();
 
@@ -7,7 +7,7 @@ export const SetProvider = ({children }) =>{
 
     const [setelements, setSetelements] = useState([
         //it should be filled with objects with the following form:
-        //{sets: ['name of the set'], items: [element1, element2 ... elementn]}
+        //{sets: ['name of the set'], elements: [element1, element2 ... elementn]}
     ])
 
      // this will transform the setelements in an array of objects with the following form:
@@ -16,11 +16,8 @@ export const SetProvider = ({children }) =>{
     //     //note: by default all sets have a cardinality of 12, it will be changed in the future to change in function of the items stored in that set   
     //     //TODO: manage intersection logic    
     const drawInstructions = () => setelements.map(element => {
-        return {sets: element.sets, size: element.items?.length || 12}
-    } );
-   
-       
-         
+        return {sets: element.sets, size: element.elements?.length || 12}
+    } ); 
     
     const addSet = (e) => {
         e.preventDefault()
@@ -28,6 +25,7 @@ export const SetProvider = ({children }) =>{
         const newSetelements = [...setelements, {sets: [`${setname}`], elements:[]}]
 
         setSetelements(newSetelements)
+        console.log(setelements)
     }
     
 
@@ -35,15 +33,16 @@ export const SetProvider = ({children }) =>{
         e.preventDefault()
         const elementsTxt = e.target.elements.setelements.value
         const elements = elementsTxt.split(',')
-        const setname = e.target.elements[0].className
-       
+        const setname = e.target.elements[0].id
+       console.log(setname)
         for(let setels of setelements){
             if(setels.sets.join('') === setname){
-                setels.items = elements;
-                setSetelements(setelements)
+                setels.elements = elements;
+                //destructures the elements array for it to change the object reference and force a re-render of Venn
+                const newElements = [...setelements]
+                setSetelements(newElements)
             }
         }
-       
     }
     return( 
        <SetContext.Provider value={{ setelements,addSet, modifySet, drawInstructions}}>

--- a/src/Context/index.jsx
+++ b/src/Context/index.jsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from "react";
+import React from "react";
 import { createContext, useState } from "react";
 export const SetContext = createContext();
 
@@ -9,23 +9,98 @@ export const SetProvider = ({children }) =>{
         //it should be filled with objects with the following form:
         //{sets: ['name of the set'], elements: [element1, element2 ... elementn]}
     ])
-
-     // this will transform the setelements in an array of objects with the following form:
+    //store all intersections, with no repeated values, to control further intersection logic
+    let allIntersectionsPossible = []
+    // this will transform the setelements in an array of objects with the following form:
     //     //{sets: ['name of the set'], size: <int: cardinality of the set>}
     //     //these objects are necessary for the Venn component to diagram them     
     //     //note: by default all sets have a cardinality of 12, it will be changed in the future to change in function of the items stored in that set   
     //     //TODO: manage intersection logic    
-    const drawInstructions = () => setelements.map(element => {
-        return {sets: element.sets, size: element.elements?.length || 12}
-    } ); 
+    const drawInstructions = () => {
+        let instructions = []
+        let setelsInstructions = setelements.map(element => {
+            return {sets: element.sets, size: element.elements?.length || 12}
+        })
+        let intersectInstructions = allIntersectionsPossible.map(el =>{
+            return {sets: el, size: 3}
+        })
+        instructions = [...setelsInstructions, ...intersectInstructions]
+        return instructions
+    }
+    
+    /*CODE BELOW THIS LINE IS PART OF THE POSSIBLE INTERSECTIONS FUNCTION*/
+    let allSetsAvailable = setelements.map(el => el.sets.join(''))
+    //starts like this, then it will change to the intersections evaluated at the end of the function
+    let currentIntersectionsEvaluated = [...allSetsAvailable]
+
+    const possibleIntersections = (intersectionsToEvaluate, allSets) => {
+        //intersections to evalate will be the previous evaluated intersections
+
+        //this is just so it can be splited below if they are arrays, transforming every element into a string
+        let intersectSet = [...intersectionsToEvaluate]
+    
+        //if the first element is an array, is an intersection, transform it to plain text to evaluate it later
+        if(typeof intersectionsToEvaluate[0] === 'object'){
+            intersectSet = intersectionsToEvaluate.map(el => el.join(','))
+        }
+        //stores the new intersections with duplicates, before purging
+        let newIntersections = []
+        //this will loop through every current intersection
+        for(let i = 0; i< intersectSet.length; i++){
+            //this other loop is to evaluate every intersection with every element available
+            for(let j=0; j<allSets.length; j++){
+                let currSetToEval = intersectSet[i]
+                let currElToEval = allSets[j]
+                //this will be used to check if the element has been already evaluated to prevent intersections like 'A,A'
+                let elementRegexp = new RegExp(`${currElToEval}`)
+                //if it finds a match it is the same set, those intersections are redundadnt and unnecesary
+                if(!currSetToEval.match(elementRegexp)){       
+                    //sorts the intersection elements before storing them, so they can be properly purged
+                    //also adds the new element evaluated (wich is new and unique to the previous stored)
+                    let sortedIntersectionPlusEl = [...currSetToEval.split(','), currElToEval].toSorted()
+                
+                    newIntersections.push([...sortedIntersectionPlusEl])
+                }
+            }
+        }
+
+        let intersectionsTexts = newIntersections.map(el => el.join(','))
+    
+        //purge duplicates
+        let uniqueIntersectionsTexts = [... new Set(intersectionsTexts)]
+        //revert to array with unique elements
+        let purgedIntersections = uniqueIntersectionsTexts.map(el => el.split(','))
+
+        //puts every intersection evaluated for future use
+        currentIntersectionsEvaluated = [...purgedIntersections]
+
+        return purgedIntersections  
+
+    }
+    //this for statement runs the function for every set so it can get all intersections possible
+    
+        for(let r = 0; r < setelements.length; r++){
+            let freshIntersections = possibleIntersections(currentIntersectionsEvaluated, allSetsAvailable)
+            if(freshIntersections.length > 0){
+                allIntersectionsPossible = [...allIntersectionsPossible, ...freshIntersections]
+            }
+        }
+        const intersectionsToAdd = allIntersectionsPossible.map(el => {
+            return {sets: [...el], elements:[]}
+        })
+        const addIntersections = []
+        if(intersectionsToAdd.length > 0){
+            addIntersections.push(intersectionsToAdd)
+        }
+        console.log(allIntersectionsPossible)
+        console.log(intersectionsToAdd)   
     
     const addSet = (e) => {
         e.preventDefault()
         const setname = e.target.elements.setname.value
         const newSetelements = [...setelements, {sets: [`${setname}`], elements:[]}]
 
-        setSetelements(newSetelements)
-        console.log(setelements)
+        setSetelements(newSetelements)  
     }
     
 
@@ -34,7 +109,7 @@ export const SetProvider = ({children }) =>{
         const elementsTxt = e.target.elements.setelements.value
         const elements = elementsTxt.split(',')
         const setname = e.target.elements[0].id
-       console.log(setname)
+        console.log(setname)
         for(let setels of setelements){
             if(setels.sets.join('') === setname){
                 setels.elements = elements;

--- a/src/components/DisplayInSidebar.jsx
+++ b/src/components/DisplayInSidebar.jsx
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react'
+import SetContentForms from './SetContentForms'
+import { SetContext } from '../Context';
+
+export default function DisplayInSidebar({display}) {
+  const context = useContext(SetContext)
+
+  if(display == 'setforms'){
+    return (
+      <SetContentForms/>
+    )
+  }
+  if(display == 'setsavail'){
+    return (
+      <div id='set-btns'>
+          {context.setelements.map(el => (
+            <button className='setavailbtn' key={`set${el.sets.join('')}`}>{el.sets.join('')}</button>
+          ))}
+      </div>
+    )
+    
+    
+  }
+  if(display == 'setcont'){
+    return context.setelements.map(el => (
+      <div className='setelements-display' key={`${el.sets.join('')}-els-disp`}>
+        <h5 className='el-display-h5'>
+          Properties of set {`${el.sets}`}:
+        </h5>
+        <div className='el-display-p-cont'>
+          <p className='display-p-label'>Elements:</p>
+          <p className='elems-p'>
+            {el.elements.join(',')}
+          </p> 
+        </div>
+        <div className='card-display-p-cont'>
+          <p>Cardinality</p>
+          <p className='elems-p'>
+            {`${el.elements.length}`}
+          </p>
+        </div>
+      </div>
+    ))
+  }
+}

--- a/src/components/Keyboard.jsx
+++ b/src/components/Keyboard.jsx
@@ -1,26 +1,43 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
+import { SetContext } from '../Context'
 
 export default function Keyboard() {
   const [inputVal, setInputVal] = useState('')
   const addInputVal = (val)=>{
     setInputVal(inputVal + val)
   }
+  const context = useContext(SetContext)
   return (
     <div id="setkeyboard">
-      <input type="text" id='keyboard-input' value={inputVal}/>
+      <div id='keyboard-input'>
+        <p type="text" id='keyboard-input'>{inputVal}</p>
+        <button id='send-keyboard'></button>
+      </div>
       <div id='keyboard-btns'>
-        <button id="btn1" className='keyboardbtn' onClick={()=>{addInputVal('1')}}>1</button>
-        <button id="btn2" className='keyboardbtn'>2</button>
-        <button id="btn3" className='keyboardbtn'>3</button>
-        <button id="btn4" className='keyboardbtn'>4</button>
-        <button id="btn5" className='keyboardbtn'>5</button>
-        <button id="btn6" className='keyboardbtn'>6</button>
-        <button id="btn7" className='keyboardbtn'>7</button>
-        <button id="btn8" className='keyboardbtn'>8</button>
-        <button id="btn9" className='keyboardbtn'>9</button>
-        <button id="btn<" className='keyboardbtn'>{`<`}</button>
-        <button id="btn0" className='keyboardbtn'>0</button>
-        <button id="btn>" className='keyboardbtn'>{`>`}</button>
+        <div id='setpad'>
+          <button id="btn1" className='keyboardbtn' onClick={()=>{addInputVal('1')}}>1</button>
+          <button id="btn2" className='keyboardbtn' onClick={()=>{addInputVal('2')}}>2</button>
+          <button id="btn3" className='keyboardbtn' onClick={()=>{addInputVal('3')}}>3</button>
+          <button id="btn4" className='keyboardbtn' onClick={()=>{addInputVal('4')}}>4</button>
+          <button id="btn5" className='keyboardbtn' onClick={()=>{addInputVal('5')}}>5</button>
+          <button id="btn6" className='keyboardbtn' onClick={()=>{addInputVal('6')}}>6</button>
+          <button id="btn7" className='keyboardbtn' onClick={()=>{addInputVal('7')}}>7</button>
+          <button id="btn8" className='keyboardbtn' onClick={()=>{addInputVal('8')}}>8</button>
+          <button id="btn9" className='keyboardbtn' onClick={()=>{addInputVal('9')}}>9</button>
+          <button id="btn<" className='keyboardbtn'>{`<`}</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('0')}}>0</button>
+          <button id="btn>" className='keyboardbtn'>{`>`}</button>
+        </div>
+        <div id='oppad'>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('∪')}}>∪</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('∩')}}>∩</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal("'")}}>'</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('-')}}>-</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('△')}}>△</button>
+          <button id="btn0" className='keyboardbtn' onClick={()=>{addInputVal('N()')}}>{`N()`}</button>
+        </div>
+        
+        
       </div>
     </div>
   )

--- a/src/components/Keyboard.jsx
+++ b/src/components/Keyboard.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+
+export default function Keyboard() {
+  const [inputVal, setInputVal] = useState('')
+  const addInputVal = (val)=>{
+    setInputVal(inputVal + val)
+  }
+  return (
+    <div id="setkeyboard">
+      <input type="text" id='keyboard-input' value={inputVal}/>
+      <div id='keyboard-btns'>
+        <button id="btn1" className='keyboardbtn' onClick={()=>{addInputVal('1')}}>1</button>
+        <button id="btn2" className='keyboardbtn'>2</button>
+        <button id="btn3" className='keyboardbtn'>3</button>
+        <button id="btn4" className='keyboardbtn'>4</button>
+        <button id="btn5" className='keyboardbtn'>5</button>
+        <button id="btn6" className='keyboardbtn'>6</button>
+        <button id="btn7" className='keyboardbtn'>7</button>
+        <button id="btn8" className='keyboardbtn'>8</button>
+        <button id="btn9" className='keyboardbtn'>9</button>
+        <button id="btn<" className='keyboardbtn'>{`<`}</button>
+        <button id="btn0" className='keyboardbtn'>0</button>
+        <button id="btn>" className='keyboardbtn'>{`>`}</button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SetForm.jsx
+++ b/src/components/SetForm.jsx
@@ -6,7 +6,7 @@ export default function SetForm({setname}) {
     const modifySet = context.modifySet
     return (
         <form onSubmit={modifySet} className='setelements-form'>
-            <label htmlFor={`set${setname}elements`} className='setelements-label'>Add elements to set: {`${setname}`}</label>
+            <label htmlFor={`${setname}`} className='setelements-label'>Add elements to set: {`${setname}`}</label>
             <input type="text" placeholder='Separate every element with a comma' id={setname} name='setelements' className='setelements-input'/>
             <button type='submit' className='setelements-btn'>Add</button>
         </form>

--- a/src/components/SetForm.jsx
+++ b/src/components/SetForm.jsx
@@ -7,7 +7,7 @@ export default function SetForm({setname}) {
     return (
         <form onSubmit={modifySet} className='setelements-form'>
             <label htmlFor={`set${setname}elements`} className='setelements-label'>Add elements to set: {`${setname}`}</label>
-            <input type="text" placeholder='Separate every element with a comma' id={`set${setname}elements`} name='setelements' className={setname}/>
+            <input type="text" placeholder='Separate every element with a comma' id={setname} name='setelements' className='setelements-input'/>
             <button type='submit' className='setelements-btn'>Add</button>
         </form>
     )

--- a/src/components/SetForm.jsx
+++ b/src/components/SetForm.jsx
@@ -5,10 +5,10 @@ export default function SetForm({setname}) {
     const context = useContext(SetContext)
     const modifySet = context.modifySet
     return (
-        <form onSubmit={modifySet}>
-            <label htmlFor={`set${setname}elements`}>Add elements to set: {`${setname}`}</label>
+        <form onSubmit={modifySet} className='setelements-form'>
+            <label htmlFor={`set${setname}elements`} className='setelements-label'>Add elements to set: {`${setname}`}</label>
             <input type="text" placeholder='Separate every element with a comma' id={`set${setname}elements`} name='setelements' className={setname}/>
-            <button type='submit'>Add elements</button>
+            <button type='submit' className='setelements-btn'>Add</button>
         </form>
     )
 }   

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,26 +1,32 @@
 import React, { useState } from 'react'
 import SetContentForms from './SetContentForms'
+import DisplayInSidebar from './DisplayInSidebar'
 
 export default function Sidebar() {
     const [isSidebarVisible, changeSidebar] = useState(true)
-    
+
+    const [sidebarShown, setSidebarShown] = useState('setforms')
+
     const toggleSidebar = ()=>{
         changeSidebar(!isSidebarVisible)
-
-        if(isSidebarVisible){
-            document.getElementById('sidebar').style.visibility = 'visible'
-        } 
-        if(!isSidebarVisible){
-            document.getElementById('sidebar').style.visibility = 'hidden'
-        }
+    }
+    const showInSidebar = (menu)=>{
+        setSidebarShown(menu)
     }
     return (
-        <div id='sidebar-container'>
+        <>
             <button onClick={toggleSidebar} id='toggle-sidebar'>Toggle Sidebar</button>
-            <div id='sidebar'>
-                <SetContentForms/>
+            <div id='sidebar-menu'>
+                <button onClick={()=>{showInSidebar('setforms')}}>Content Forms</button>
+                <button onClick={()=>{showInSidebar('setsavail')}}>Available Sets</button>
+                <button onClick={()=>{showInSidebar('setcont')}}>Sets contents</button>
             </div>
-        </div>
+            <div id='sidebar' className={isSidebarVisible ? 'sidebar-active':'sidebar-inactive'}>
+                <DisplayInSidebar display={sidebarShown}>
+
+                </DisplayInSidebar>
+            </div>
+        </>
         
     )
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+import SetContentForms from './SetContentForms'
+
+export default function Sidebar() {
+    const [isSidebarVisible, changeSidebar] = useState(true)
+    
+    const toggleSidebar = ()=>{
+        changeSidebar(!isSidebarVisible)
+
+        if(isSidebarVisible){
+            document.getElementById('sidebar').style.visibility = 'visible'
+        } 
+        if(!isSidebarVisible){
+            document.getElementById('sidebar').style.visibility = 'hidden'
+        }
+    }
+    return (
+        <div id='sidebar-container'>
+            <button onClick={toggleSidebar} id='toggle-sidebar'>Toggle Sidebar</button>
+            <div id='sidebar'>
+                <SetContentForms/>
+            </div>
+        </div>
+        
+    )
+}

--- a/src/components/Venn.js
+++ b/src/components/Venn.js
@@ -7,15 +7,16 @@ import { VennDiagram } from "venn.js";
 import * as d3 from "d3";
 function Venn(){
     const context = useContext(SetContext);
-    
+
     useEffect(() => {
-        console.log("Xd")
         var sets = context.drawInstructions();
         
         var chart = VennDiagram()
         d3.select("#venn").datum(sets).call(chart);
 
-      }, [context.setelements, context.setelements.items]); //Every time the context changes, the diagram does aswell
+      //Every time the context changes, the diagram does aswell
+      //or every time the set sizes are altered, a render is forced
+      }, [context.setelements]); 
     return(
         <div id="venn"> 
         </div>

--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -1,20 +1,25 @@
-import React, { useContext } from "react";
-import { SetProvider, SetContext } from "../Context";
+import React from "react";
+import { SetProvider } from "../Context";
 import SetAdding from "../components/SetAdding";
-import SetContentForms from "../components/SetContentForms";
 
 import Venn from "../components/Venn";
+import Sidebar from "../components/Sidebar";
+import Keyboard from "../components/Keyboard";
 function App(){
     return (
-        <div id="app">
-            <section id="diagramPlusForm-container">
-                <SetProvider>        
+        <div id="setprovider-container">
+            <SetProvider>
+                <section id="diagramPlusForm-container">
                     <Venn/>
                     <SetAdding/>
-
-                    <SetContentForms/>
-                </SetProvider>
-            </section>   
+                </section>
+                <section id="sidebar-container">
+                    <Sidebar/>
+                </section>
+                <section id="keyboard-container">
+                    <Keyboard/>
+                </section>
+            </SetProvider>
         </div>    
     )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -31,6 +31,7 @@ input{
     grid-column: 2/3;
     grid-row: 1/2;
 }
+
 #venn{
     margin: 0;
     width: 90%;
@@ -62,27 +63,46 @@ input{
     width: 100%;
     grid-column: 1/2;
     grid-row: 1/2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-flow: column nowrap;
+    display: grid;
+    grid-template-columns: 15% 85%;
+    grid-template-rows: 15% 85%;
 }
 #sidebar{
     border: 1px solid black;
-    width: 90%;
+    width: 100%;
     height: 100%;
-    flex-flow: column, nowrap;
+    flex-flow: column nowrap;
     display: flex;
     align-items: flex-start;
+    justify-content: center;
     overflow-y: scroll;
     overflow-x: hidden;
+    grid-column: 2/3;
+    grid-row: 1/3;
 }
 #toggle-sidebar{
     align-self: start;
-    margin-left: 1.5vw;
+    grid-column: 1/2;
+    grid-row: 1/2;
+    height: 100%;
+    width: 100%;
+}
+#sidebar-menu{
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    justify-content: center;
+    grid-row: 2/3;
+    grid-column: 1/2;
+}
+.sidebar-active{
+    visibility: visible;
+}
+.sidebar-inactive{
+    visibility: hidden;
 }
 .setelements-form{
-    width: 25vw;
+    width: 22.5vw;
     height: 5vh;
     margin: 1rem 0 1rem 0;
     display: grid;
@@ -125,7 +145,69 @@ input{
 }
 #keyboard-btns{
     display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-row: 2/3;
+}
+#setpad{
+    display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(4, 1fr);
+}
+#oppad{
+    display: grid;
+    grid-template-columns: repeat(3,1fr);
+    grid-template-rows: repeat(2,1fr);
+}
+#keyboard-input{
+    border: 1px solid black;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.setelements-display{
+    width: 99%;
+    height: auto;
+    margin-bottom: 0.5vh;
+    border: 1px solid black;
+    display: grid;
+    grid-template-columns: 70% 30%;
+    grid-template-rows: repeat(2, 1fr);
+}
+.el-display-h5{
+    text-align: center;
+    width: 100%;
+    height: 1vh;
+    grid-column: 1/3;
+    grid-row: 1/2;
+    
+}
+.el-display-p-cont{
+    width: 100%;
+    height: auto;
+    overflow-x: scroll;
     grid-row: 2/3;
+    grid-column: 1/2;
+}
+.card-display-p-cont{
+    width: 100%;
+    margin-top: 1vh;
+    height: 100%;
+    grid-row: 2/3;
+    grid-column: 2/3;
+}
+.setavailbtn{
+    width: 1;
+}
+#set-btns{
+    display: flex;
+    flex-wrap: wrap;
+    width: 20vw;
+}
+.setavailbtn{
+    width: 4vw;
+    height: 4vw;
+}
+.elems-p{
+    width: 100%;
+    text-align: center;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -73,8 +73,8 @@ input{
     height: 100%;
     flex-flow: column nowrap;
     display: flex;
-    align-items: flex-start;
-    justify-content: center;
+    align-items: center;
+    justify-content: flex-start;
     overflow-y: scroll;
     overflow-x: hidden;
     grid-column: 2/3;

--- a/src/style.css
+++ b/src/style.css
@@ -21,20 +21,21 @@ input{
     display: inline-block;
 }
 #diagramPlusForm-container{
-    width: 100vw;
-    height: 95vh;
+    width: 100%;
+    height: 100%;
     margin-top: 1vh;
     display: flex;
     flex-flow: column;
     justify-content: center;
     align-items: center;
+    grid-column: 2/3;
+    grid-row: 1/2;
 }
 #venn{
     margin: 0;
-    width: 90vw;
-    height: 80vh;
-    padding-left:2.5vw;
-    padding-right: 2.5vw;
+    width: 90%;
+    height: 80%;
+    padding: 0 1rem 0 1rem;
     border: 1px solid black;
     display: flex;
     align-items: center;
@@ -49,4 +50,82 @@ input{
 }
 #addsetLabel{
     margin-right: 1vw;
+}
+#setprovider-container{
+    width: 100vw;
+    display: grid;
+    grid-template-columns: 30vw 70vw;
+    grid-template-rows: 65vh 35vh;
+}
+#sidebar-container{
+    height: 100%;
+    width: 100%;
+    grid-column: 1/2;
+    grid-row: 1/2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-flow: column nowrap;
+}
+#sidebar{
+    border: 1px solid black;
+    width: 90%;
+    height: 100%;
+    flex-flow: column, nowrap;
+    display: flex;
+    align-items: flex-start;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+#toggle-sidebar{
+    align-self: start;
+    margin-left: 1.5vw;
+}
+.setelements-form{
+    width: 25vw;
+    height: 5vh;
+    margin: 1rem 0 1rem 0;
+    display: grid;
+    grid-template-columns: 85% 15%;
+    grid-template-rows: repeat(50%, 2);
+    padding: 0.5rem;
+}
+.setelements-label{
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    grid-column: 1/3;
+    grid-row: 1/2;
+}
+.setelements-btn{
+    width: 100%;
+    height: 100%;
+    grid-column: 2/3;
+    grid-row: 2/3;
+}
+#keyboard-container{
+    width: 100%;
+    height: 100%;
+    grid-row: 2/3;
+    grid-column: 1/3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.keyboardbtn{
+    width: 100%;
+    height: 100%;
+}
+#setkeyboard{
+    width: 40%;
+    height: 90%;
+    display: grid;
+    grid-template-rows: 20% 80%;
+    grid-row: 1/2;
+}
+#keyboard-btns{
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    grid-row: 2/3;
 }


### PR DESCRIPTION
Added a sidebar with a menu that displays the forms required to alter the set elements info, the available sets as buttons to manage further set operations (intersection, union, etcetera...) and the set properties such as elements and cardinality, also added a keyboard wich serves as a template for future set operations, and now in the last two commits the Venn component draws every intersection possible without a limit of sets to display, tested up to 10 intersections ('A','B','C','D','E','F','G','H','I','J','K'), improved the function that gets those intersections a bit to prevent my browser from crashing when trying to diagram those 10 sets with their intersections